### PR TITLE
Skip comments when validating custom properties

### DIFF
--- a/lib/validate-properties.js
+++ b/lib/validate-properties.js
@@ -21,7 +21,10 @@ function validateCustomProperties(rules, componentName) {
   rules.forEach(function (rule) {
     if (!isValidRule(rule) || rule.selectors[0] !== ':root') return;
 
-    rule.declarations.forEach(function (declaration) {
+    rule.declarations.filter(function(declaration) {
+      // skip comments
+      return declaration.type === 'declaration';
+    }).forEach(function (declaration) {
       var column = declaration.position.start.column;
       var line = declaration.position.start.line;
       var property = declaration.property;

--- a/test/fixtures/all-valid-root-vars-with-comments.css
+++ b/test/fixtures/all-valid-root-vars-with-comments.css
@@ -1,0 +1,5 @@
+/** @define ValidRootVars */
+
+:root {
+  --ValidRootVars-color: green; /* comment */
+}

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,7 @@ describe('linting', function () {
 
     it('must only declare custom properties, containing the component name, in a `:root` rule', function () {
       assertSuccess('all-valid-root-vars');
+      assertSuccess('all-valid-root-vars-with-comments');
       assertFailure('all-invalid-root-vars');
       assertFailure('all-invalid-root-property');
       assertFailure('all-invalid-root-selector');


### PR DESCRIPTION
The following code was resulting in unexpected failures because _validate-properties.js_ was process comments as if they were declarations i.e. there was an expectation `property` was defined and a string.

``` css
/** @define ValidRootVars */

:root {
  --ValidRootVars-color: green; /* comment */
}
```

This patch updates _validate-properties.js_ to skip comments when validation custom properties.
